### PR TITLE
Add support for getting/setting comment

### DIFF
--- a/src/anytag.rs
+++ b/src/anytag.rs
@@ -16,6 +16,7 @@ pub struct AnyTag<'a> {
     pub total_discs: Option<u16>,
     pub genre: Option<&'a str>,
     pub composer: Option<&'a str>,
+    pub comment: Option<&'a str>,
 }
 
 impl AudioTagConfig for AnyTag<'_> {
@@ -70,6 +71,9 @@ impl<'a> AnyTag<'a> {
     }
     pub fn composer(&self) -> Option<&str> {
         self.composer
+    }
+    pub fn comment(&self) -> Option<&str> {
+        self.comment
     }
 }
 

--- a/src/components/flac_tag.rs
+++ b/src/components/flac_tag.rs
@@ -55,6 +55,7 @@ impl<'a> From<&'a FlacTag> for AnyTag<'a> {
             total_discs: inp.total_discs(),
             genre: inp.genre(),
             composer: inp.composer(),
+            comment: inp.comment(),
             ..Self::default()
         };
 
@@ -249,6 +250,16 @@ impl AudioTagEdit for FlacTag {
     }
     fn remove_genre(&mut self) {
         self.remove("GENRE");
+    }
+
+    fn comment(&self) -> Option<&str> {
+        self.get_first("COMMENT")
+    }
+    fn set_comment(&mut self, v: String) {
+        self.set_first("COMMENT", &v);
+    }
+    fn remove_comment(&mut self) {
+        self.remove("COMMENT");
     }
 }
 

--- a/src/components/id3_tag.rs
+++ b/src/components/id3_tag.rs
@@ -261,7 +261,7 @@ impl AudioTagEdit for Id3v2Tag {
     }
     fn set_comment(&mut self, comment: String) {
         self.inner.add_frame(id3::frame::Comment {
-            lang: "".to_string(),
+            lang: "XXX".to_string(),
             description: "".to_string(),
             text: comment,
         });

--- a/src/components/id3_tag.rs
+++ b/src/components/id3_tag.rs
@@ -23,6 +23,7 @@ impl<'a> From<&'a Id3v2Tag> for AnyTag<'a> {
             total_discs: inp.total_discs(),
             genre: inp.genre(),
             composer: inp.composer(),
+            comment: inp.comment(),
         }
     }
 }
@@ -248,6 +249,25 @@ impl AudioTagEdit for Id3v2Tag {
     }
     fn remove_genre(&mut self) {
         self.inner.remove_genre();
+    }
+
+    fn comment(&self) -> Option<&str> {
+        for comment in self.inner.comments() {
+            if comment.description.is_empty() {
+                return Some(comment.text.as_str());
+            }
+        }
+        None
+    }
+    fn set_comment(&mut self, comment: String) {
+        self.inner.add_frame(id3::frame::Comment {
+            lang: "".to_string(),
+            description: "".to_string(),
+            text: comment,
+        });
+    }
+    fn remove_comment(&mut self) {
+        self.inner.remove("COMM");
     }
 }
 

--- a/src/components/mp4_tag.rs
+++ b/src/components/mp4_tag.rs
@@ -24,6 +24,7 @@ impl<'a> From<&'a Mp4Tag> for AnyTag<'a> {
         let total_discs = b;
         let genre = inp.genre();
         let composer = inp.composer();
+        let comment = inp.comment();
         Self {
             config: inp.config,
             title,
@@ -39,6 +40,7 @@ impl<'a> From<&'a Mp4Tag> for AnyTag<'a> {
             total_discs,
             genre,
             composer,
+            comment,
         }
     }
 }
@@ -282,6 +284,16 @@ impl AudioTagEdit for Mp4Tag {
     }
     fn remove_genre(&mut self) {
         self.inner.remove_genres();
+    }
+
+    fn comment(&self) -> Option<&str> {
+        self.inner.comment()
+    }
+    fn set_comment(&mut self, comment: String) {
+        self.inner.set_comment(comment);
+    }
+    fn remove_comment(&mut self) {
+        self.inner.remove_comments();
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -134,6 +134,10 @@ pub trait AudioTagEdit: AudioTagConfig {
     fn genre(&self) -> Option<&str>;
     fn set_genre(&mut self, genre: &str);
     fn remove_genre(&mut self);
+
+    fn comment(&self) -> Option<&str>;
+    fn set_comment(&mut self, genre: String);
+    fn remove_comment(&mut self);
 }
 
 pub trait AudioTagWrite {

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -62,6 +62,12 @@ macro_rules! test_file {
             tags.remove_genre();
             assert!(tags.genre().is_none());
             tags.remove_genre();
+
+            tags.set_comment("foo song comment".to_string());
+            assert_eq!(tags.comment(), Some("foo song comment"));
+            tags.remove_comment();
+            assert!(tags.comment().is_none());
+            tags.remove_comment();
         }
     };
 }


### PR DESCRIPTION
Currently mack[0] only supports ID3 tags, and I'd like to allow it to also support FLAC and M4A. It currently uses the comment field as presented by rust-id3, but audiotags doesn't expose this. This commit adds support to that effect.

0: https://github.com/cdown/mack