### PR TITLE
copy album artist to album artist

### DIFF
--- a/src/components/flac_tag.rs
+++ b/src/components/flac_tag.rs
@@ -21,7 +21,7 @@ impl<'a> From<AnyTag<'a>> for FlacTag {
             t.set_album_title(v)
         }
         if let Some(v) = inp.album_artists_as_string() {
-            t.set_artist(&v)
+            t.set_album_artist(&v)
         }
         if let Some(v) = inp.track_number() {
             t.set_track_number(v)

--- a/src/components/id3_tag.rs
+++ b/src/components/id3_tag.rs
@@ -47,7 +47,7 @@ impl<'a> From<AnyTag<'a>> for Id3v2Tag {
                     t.set_album(v)
                 }
                 if let Some(v) = inp.album_artists_as_string() {
-                    t.set_artist(&v)
+                    t.set_album_artist(&v)
                 }
                 if let Some(v) = inp.track_number() {
                     t.set_track(v as u32)

--- a/tests/inner.rs
+++ b/tests/inner.rs
@@ -11,9 +11,14 @@ fn test_inner() {
     let tmp_path = tmp.path();
 
     let mut innertag = metaflac::Tag::default();
+    let title = "title from metaflac::Tag";
+    let artist = "Billy Foo";
+    let album_artist = "Billy Foo & The Bars";
+    innertag.vorbis_comments_mut().set_title(vec![title]);
+    innertag.vorbis_comments_mut().set_artist(vec![artist]);
     innertag
         .vorbis_comments_mut()
-        .set_title(vec!["title from metaflac::Tag"]);
+        .set_album_artist(vec![album_artist]);
 
     let tag: FlacTag = innertag.into();
     let mut id3tag = tag.to_dyn_tag(TagType::Id3v2);
@@ -26,7 +31,9 @@ fn test_inner() {
         .read_from_path(tmp_path)
         .expect("Fail to read!");
 
-    assert_eq!(id3tag_reload.title(), Some("title from metaflac::Tag"));
+    assert_eq!(id3tag_reload.title(), Some(title));
+    assert_eq!(id3tag_reload.artist(), Some(artist));
+    assert_eq!(id3tag_reload.album_artist(), Some(album_artist));
 
     // let id3tag: Id3v2Tag = id3tag_reload.into();
     let mut id3tag_inner: id3::Tag = id3tag_reload.into();
@@ -46,4 +53,6 @@ fn test_inner() {
 
     let id3tag_reload = id3::Tag::read_from_path(tmp_path).expect("Fail to read!");
     assert_eq!(id3tag_reload.date_recorded(), Some(timestamp));
+    assert_eq!(id3tag_reload.artist(), Some(artist));
+    assert_eq!(id3tag_reload.album_artist(), Some(album_artist));
 }


### PR DESCRIPTION
Hello,

I hope that this PR finds you well. Thanks for this nice library.

I noticed that the album artist string appears to get copied to the artist, rather than the album artist when dyn tags are used. I believe I have corrected the issue. I tried the supplied test with and without the change and it appears to fail without the changes. Do you think this would make sense to change?

Thanks