### PR TITLE
Feat/add full date capabilities

### DIFF
--- a/src/anytag.rs
+++ b/src/anytag.rs
@@ -1,10 +1,14 @@
 use crate::*;
+use id3::Timestamp;
 
 #[derive(Default)]
 pub struct AnyTag<'a> {
     pub config: Config,
     pub title: Option<&'a str>,
     pub artists: Option<Vec<&'a str>>,
+    pub date_released: Option<Timestamp>,
+    pub original_date_released: Option<Timestamp>,
+    pub date_recorded: Option<Timestamp>,
     pub year: Option<i32>,
     pub duration: Option<f64>,
     pub album_title: Option<&'a str>,
@@ -39,6 +43,24 @@ impl<'a> AnyTag<'a> {
         self.artists.as_deref()
     }
     // set_artists; add_artist
+    pub fn date_released(&self) -> Option<Timestamp> {
+        self.date_released
+    }
+    pub fn set_date_released(&mut self, date_released: Timestamp) {
+        self.date_released = Some(date_released);
+    }
+    pub fn original_date_released(&self) -> Option<Timestamp> {
+        self.original_date_released
+    }
+    pub fn set_original_date_released(&mut self, original_date_released: Timestamp) {
+        self.original_date_released = Some(original_date_released);
+    }
+    pub fn date_recorded(&self) -> Option<Timestamp> {
+        self.date_recorded
+    }
+    pub fn set_date_recorded(&mut self, date_recorded: Timestamp) {
+        self.date_recorded = Some(date_recorded);
+    }
     pub fn year(&self) -> Option<i32> {
         self.year
     }

--- a/src/anytag.rs
+++ b/src/anytag.rs
@@ -6,9 +6,7 @@ pub struct AnyTag<'a> {
     pub config: Config,
     pub title: Option<&'a str>,
     pub artists: Option<Vec<&'a str>>,
-    pub date_released: Option<Timestamp>,
-    pub original_date_released: Option<Timestamp>,
-    pub date_recorded: Option<Timestamp>,
+    pub date: Option<Timestamp>,
     pub year: Option<i32>,
     pub duration: Option<f64>,
     pub album_title: Option<&'a str>,
@@ -43,23 +41,11 @@ impl<'a> AnyTag<'a> {
         self.artists.as_deref()
     }
     // set_artists; add_artist
-    pub fn date_released(&self) -> Option<Timestamp> {
-        self.date_released
+    pub fn date(&self) -> Option<Timestamp> {
+        self.date
     }
-    pub fn set_date_released(&mut self, date_released: Timestamp) {
-        self.date_released = Some(date_released);
-    }
-    pub fn original_date_released(&self) -> Option<Timestamp> {
-        self.original_date_released
-    }
-    pub fn set_original_date_released(&mut self, original_date_released: Timestamp) {
-        self.original_date_released = Some(original_date_released);
-    }
-    pub fn date_recorded(&self) -> Option<Timestamp> {
-        self.date_recorded
-    }
-    pub fn set_date_recorded(&mut self, date_recorded: Timestamp) {
-        self.date_recorded = Some(date_recorded);
+    pub fn set_date(&mut self, date: Timestamp) {
+        self.date = Some(date);
     }
     pub fn year(&self) -> Option<i32> {
         self.year

--- a/src/components/flac_tag.rs
+++ b/src/components/flac_tag.rs
@@ -17,7 +17,7 @@ impl<'a> From<AnyTag<'a>> for FlacTag {
             t.set_artist(&v)
         }
         if let Some(v) = inp.date {
-            t.set_date_recorded(v)
+            t.set_date(v)
         }
         if let Some(v) = inp.year {
             t.set_year(v)
@@ -49,7 +49,7 @@ impl<'a> From<&'a FlacTag> for AnyTag<'a> {
         let tag = Self {
             title: inp.title(),
             artists: inp.artists(),
-            date: inp.date_released(),
+            date: inp.date(),
             year: inp.year(),
             duration: inp.duration(),
             album_title: inp.album_title(),
@@ -110,45 +110,17 @@ impl AudioTagEdit for FlacTag {
         self.remove("ARTIST");
     }
 
-    fn date_released(&self) -> Option<Timestamp> {
+    fn date(&self) -> Option<Timestamp> {
         if let Some(Ok(timestamp)) = self.get_first("DATE").map(Timestamp::from_str) {
             Some(timestamp)
         } else {
             None
         }
     }
-    fn set_date_released(&mut self, date_released: Timestamp) {
-        self.set_first("DATE", &date_released.to_string());
+    fn set_date(&mut self, date: Timestamp) {
+        self.set_first("DATE", &date.to_string());
     }
-    fn remove_date_released(&mut self) {
-        self.remove("DATE");
-    }
-
-    fn original_date_released(&self) -> Option<Timestamp> {
-        if let Some(Ok(timestamp)) = self.get_first("DATE").map(Timestamp::from_str) {
-            Some(timestamp)
-        } else {
-            None
-        }
-    }
-    fn set_original_date_released(&mut self, original_date_released: Timestamp) {
-        self.set_first("DATE", &original_date_released.to_string());
-    }
-    fn remove_original_date_released(&mut self) {
-        self.remove("DATE");
-    }
-
-    fn date_recorded(&self) -> Option<Timestamp> {
-        if let Some(Ok(timestamp)) = self.get_first("DATE").map(Timestamp::from_str) {
-            Some(timestamp)
-        } else {
-            None
-        }
-    }
-    fn set_date_recorded(&mut self, date_recorded: Timestamp) {
-        self.set_first("DATE", &date_recorded.to_string());
-    }
-    fn remove_date_recorded(&mut self) {
+    fn remove_date(&mut self) {
         self.remove("DATE");
     }
 

--- a/src/components/flac_tag.rs
+++ b/src/components/flac_tag.rs
@@ -177,6 +177,7 @@ impl AudioTagEdit for FlacTag {
     }
     fn remove_year(&mut self) {
         self.remove("YEAR");
+        self.remove("DATE");
     }
 
     fn duration(&self) -> Option<f64> {

--- a/src/components/flac_tag.rs
+++ b/src/components/flac_tag.rs
@@ -16,13 +16,7 @@ impl<'a> From<AnyTag<'a>> for FlacTag {
         if let Some(v) = inp.artists_as_string() {
             t.set_artist(&v)
         }
-        if let Some(v) = inp.date_released {
-            t.set_date_released(v)
-        }
-        if let Some(v) = inp.original_date_released {
-            t.set_original_date_released(v)
-        }
-        if let Some(v) = inp.date_recorded {
+        if let Some(v) = inp.date {
             t.set_date_recorded(v)
         }
         if let Some(v) = inp.year {
@@ -55,9 +49,7 @@ impl<'a> From<&'a FlacTag> for AnyTag<'a> {
         let tag = Self {
             title: inp.title(),
             artists: inp.artists(),
-            date_released: inp.date_released(),
-            original_date_released: inp.original_date_released(),
-            date_recorded: inp.date_recorded(),
+            date: inp.date_released(),
             year: inp.year(),
             duration: inp.duration(),
             album_title: inp.album_title(),

--- a/src/components/flac_tag.rs
+++ b/src/components/flac_tag.rs
@@ -1,5 +1,7 @@
 use crate::*;
+use id3::Timestamp;
 use metaflac;
+use std::str::FromStr;
 
 pub use metaflac::Tag as FlacInnerTag;
 
@@ -13,6 +15,15 @@ impl<'a> From<AnyTag<'a>> for FlacTag {
         }
         if let Some(v) = inp.artists_as_string() {
             t.set_artist(&v)
+        }
+        if let Some(v) = inp.date_released {
+            t.set_date_released(v)
+        }
+        if let Some(v) = inp.original_date_released {
+            t.set_original_date_released(v)
+        }
+        if let Some(v) = inp.date_recorded {
+            t.set_date_recorded(v)
         }
         if let Some(v) = inp.year {
             t.set_year(v)
@@ -44,6 +55,9 @@ impl<'a> From<&'a FlacTag> for AnyTag<'a> {
         let tag = Self {
             title: inp.title(),
             artists: inp.artists(),
+            date_released: inp.date_released(),
+            original_date_released: inp.original_date_released(),
+            date_recorded: inp.date_recorded(),
             year: inp.year(),
             duration: inp.duration(),
             album_title: inp.album_title(),
@@ -104,25 +118,65 @@ impl AudioTagEdit for FlacTag {
         self.remove("ARTIST");
     }
 
+    fn date_released(&self) -> Option<Timestamp> {
+        if let Some(Ok(timestamp)) = self.get_first("DATE").map(Timestamp::from_str) {
+            Some(timestamp)
+        } else {
+            None
+        }
+    }
+    fn set_date_released(&mut self, date_released: Timestamp) {
+        self.set_first("DATE", &date_released.to_string());
+    }
+    fn remove_date_released(&mut self) {
+        self.remove("DATE");
+    }
+
+    fn original_date_released(&self) -> Option<Timestamp> {
+        if let Some(Ok(timestamp)) = self.get_first("DATE").map(Timestamp::from_str) {
+            Some(timestamp)
+        } else {
+            None
+        }
+    }
+    fn set_original_date_released(&mut self, original_date_released: Timestamp) {
+        self.set_first("DATE", &original_date_released.to_string());
+    }
+    fn remove_original_date_released(&mut self) {
+        self.remove("DATE");
+    }
+
+    fn date_recorded(&self) -> Option<Timestamp> {
+        if let Some(Ok(timestamp)) = self.get_first("DATE").map(Timestamp::from_str) {
+            Some(timestamp)
+        } else {
+            None
+        }
+    }
+    fn set_date_recorded(&mut self, date_recorded: Timestamp) {
+        self.set_first("DATE", &date_recorded.to_string());
+    }
+    fn remove_date_recorded(&mut self) {
+        self.remove("DATE");
+    }
+
     fn year(&self) -> Option<i32> {
-        if let Some(Ok(y)) = self
+        if let Some(Ok(y)) = self.get_first("YEAR").map(|s| s.parse::<i32>()) {
+            Some(y)
+        } else if let Some(Ok(y)) = self
             .get_first("DATE")
             .map(|s| s.chars().take(4).collect::<String>().parse::<i32>())
         {
-            Some(y)
-        } else if let Some(Ok(y)) = self.get_first("YEAR").map(|s| s.parse::<i32>()) {
             Some(y)
         } else {
             None
         }
     }
     fn set_year(&mut self, year: i32) {
-        self.set_first("DATE", &year.to_string());
         self.set_first("YEAR", &year.to_string());
     }
     fn remove_year(&mut self) {
         self.remove("YEAR");
-        self.remove("DATE");
     }
 
     fn duration(&self) -> Option<f64> {

--- a/src/components/id3_tag.rs
+++ b/src/components/id3_tag.rs
@@ -12,9 +12,7 @@ impl<'a> From<&'a Id3v2Tag> for AnyTag<'a> {
 
             title: inp.title(),
             artists: inp.artists(),
-            date_released: inp.date_released(),
-            original_date_released: inp.original_date_released(),
-            date_recorded: inp.date_recorded(),
+            date: inp.date_recorded(),
             year: inp.year(),
             duration: Some(inp.inner.duration().unwrap() as f64),
             album_title: inp.album_title(),
@@ -43,13 +41,7 @@ impl<'a> From<AnyTag<'a>> for Id3v2Tag {
                 if let Some(v) = inp.artists_as_string() {
                     t.set_artist(&v)
                 }
-                if let Some(v) = inp.date_released() {
-                    t.set_date_released(v)
-                }
-                if let Some(v) = inp.original_date_released() {
-                    t.set_original_date_released(v)
-                }
-                if let Some(v) = inp.date_recorded() {
+                if let Some(v) = inp.date() {
                     t.set_date_recorded(v)
                 }
                 if let Some(v) = inp.year {

--- a/src/components/id3_tag.rs
+++ b/src/components/id3_tag.rs
@@ -12,6 +12,9 @@ impl<'a> From<&'a Id3v2Tag> for AnyTag<'a> {
 
             title: inp.title(),
             artists: inp.artists(),
+            date_released: inp.date_released(),
+            original_date_released: inp.original_date_released(),
+            date_recorded: inp.date_recorded(),
             year: inp.year(),
             duration: Some(inp.inner.duration().unwrap() as f64),
             album_title: inp.album_title(),
@@ -39,6 +42,15 @@ impl<'a> From<AnyTag<'a>> for Id3v2Tag {
                 }
                 if let Some(v) = inp.artists_as_string() {
                     t.set_artist(&v)
+                }
+                if let Some(v) = inp.date_released() {
+                    t.set_date_released(v)
+                }
+                if let Some(v) = inp.original_date_released() {
+                    t.set_original_date_released(v)
+                }
+                if let Some(v) = inp.date_recorded() {
+                    t.set_date_recorded(v)
                 }
                 if let Some(v) = inp.year {
                     t.set_year(v)
@@ -102,38 +114,43 @@ impl AudioTagEdit for Id3v2Tag {
         self.inner.remove_artist();
     }
 
-    fn year(&self) -> Option<i32> {
-        if self.inner.version() == Version::Id3v23 {
-            if let ret @ Some(_) = self.inner.year() {
-                return ret;
-            }
-        }
+    fn original_date_released(&self) -> Option<Timestamp> {
+        self.inner.original_date_released()
+    }
+    fn set_original_date_released(&mut self, timestamp: Timestamp) {
+        self.inner.set_original_date_released(timestamp)
+    }
+    fn remove_original_date_released(&mut self) {
+        self.inner.remove_original_date_released()
+    }
 
-        self.inner.date_recorded().map(|timestamp| timestamp.year)
+    fn date_released(&self) -> Option<Timestamp> {
+        self.inner.date_released()
+    }
+    fn set_date_released(&mut self, timestamp: Timestamp) {
+        self.inner.set_date_released(timestamp)
+    }
+    fn remove_date_released(&mut self) {
+        self.inner.remove_date_released()
+    }
+
+    fn date_recorded(&self) -> Option<Timestamp> {
+        self.inner.date_recorded()
+    }
+    fn set_date_recorded(&mut self, timestamp: Timestamp) {
+        self.inner.set_date_recorded(timestamp)
+    }
+    fn remove_date_recorded(&mut self) {
+        self.inner.remove_date_recorded()
+    }
+
+    fn year(&self) -> Option<i32> {
+        self.inner.year()
     }
     fn set_year(&mut self, year: i32) {
-        if self.inner.version() == Version::Id3v23 {
-            self.inner.set_year(year);
-            return;
-        }
-
-        if let Some(mut timestamp) = self.inner.date_recorded() {
-            timestamp.year = year;
-            self.inner.set_date_recorded(timestamp);
-            return;
-        }
-
-        self.inner.set_date_recorded(Timestamp {
-            year,
-            month: None,
-            day: None,
-            hour: None,
-            minute: None,
-            second: None,
-        });
+        self.inner.set_year(year);
     }
     fn remove_year(&mut self) {
-        self.inner.remove_date_recorded();
         self.inner.remove_year();
     }
     fn duration(&self) -> Option<f64> {

--- a/src/components/id3_tag.rs
+++ b/src/components/id3_tag.rs
@@ -12,7 +12,7 @@ impl<'a> From<&'a Id3v2Tag> for AnyTag<'a> {
 
             title: inp.title(),
             artists: inp.artists(),
-            date: inp.date_recorded(),
+            date: inp.date(),
             year: inp.year(),
             duration: Some(inp.inner.duration().unwrap() as f64),
             album_title: inp.album_title(),
@@ -106,33 +106,13 @@ impl AudioTagEdit for Id3v2Tag {
         self.inner.remove_artist();
     }
 
-    fn original_date_released(&self) -> Option<Timestamp> {
-        self.inner.original_date_released()
-    }
-    fn set_original_date_released(&mut self, timestamp: Timestamp) {
-        self.inner.set_original_date_released(timestamp)
-    }
-    fn remove_original_date_released(&mut self) {
-        self.inner.remove_original_date_released()
-    }
-
-    fn date_released(&self) -> Option<Timestamp> {
-        self.inner.date_released()
-    }
-    fn set_date_released(&mut self, timestamp: Timestamp) {
-        self.inner.set_date_released(timestamp)
-    }
-    fn remove_date_released(&mut self) {
-        self.inner.remove_date_released()
-    }
-
-    fn date_recorded(&self) -> Option<Timestamp> {
+    fn date(&self) -> Option<Timestamp> {
         self.inner.date_recorded()
     }
-    fn set_date_recorded(&mut self, timestamp: Timestamp) {
+    fn set_date(&mut self, timestamp: Timestamp) {
         self.inner.set_date_recorded(timestamp)
     }
-    fn remove_date_recorded(&mut self) {
+    fn remove_date(&mut self) {
         self.inner.remove_date_recorded()
     }
 

--- a/src/components/id3_tag.rs
+++ b/src/components/id3_tag.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use id3::{self, Content, Frame, TagLike, Timestamp, Version};
+use id3::{self, Content, Frame, TagLike, Timestamp};
 
 pub use id3::Tag as Id3v2InnerTag;
 

--- a/src/components/id3_tag.rs
+++ b/src/components/id3_tag.rs
@@ -123,6 +123,7 @@ impl AudioTagEdit for Id3v2Tag {
         self.inner.set_year(year);
     }
     fn remove_year(&mut self) {
+        self.inner.remove_date_recorded();
         self.inner.remove_year();
     }
     fn duration(&self) -> Option<f64> {

--- a/src/components/mp4_tag.rs
+++ b/src/components/mp4_tag.rs
@@ -1,5 +1,7 @@
 use crate::*;
+use id3::Timestamp;
 use mp4ameta::{self, ImgFmt};
+use std::str::FromStr;
 
 pub use mp4ameta::Tag as Mp4InnerTag;
 
@@ -9,6 +11,9 @@ impl<'a> From<&'a Mp4Tag> for AnyTag<'a> {
     fn from(inp: &'a Mp4Tag) -> Self {
         let title = inp.title();
         let artists = inp.artists().map(|i| i.into_iter().collect::<Vec<_>>());
+        let date_released = inp.date_released();
+        let original_date_released = inp.original_date_released();
+        let date_recorded = inp.date_recorded();
         let year = inp.year();
         let duration = inp.duration();
         let album_title = inp.album_title();
@@ -29,6 +34,9 @@ impl<'a> From<&'a Mp4Tag> for AnyTag<'a> {
             config: inp.config,
             title,
             artists,
+            date_released,
+            original_date_released,
+            date_recorded,
             year,
             duration,
             album_title,
@@ -135,6 +143,48 @@ impl AudioTagEdit for Mp4Tag {
     }
     fn add_artist(&mut self, v: &str) {
         self.inner.add_artist(v);
+    }
+
+    fn date_released(&self) -> Option<Timestamp> {
+        if let Some(Ok(date)) = self.inner.year().map(Timestamp::from_str) {
+            Some(date)
+        } else {
+            None
+        }
+    }
+    fn set_date_released(&mut self, date_released: Timestamp) {
+        self.inner.set_year(date_released.to_string())
+    }
+    fn remove_date_released(&mut self) {
+        self.inner.remove_year()
+    }
+
+    fn original_date_released(&self) -> Option<Timestamp> {
+        if let Some(Ok(date)) = self.inner.year().map(Timestamp::from_str) {
+            Some(date)
+        } else {
+            None
+        }
+    }
+    fn set_original_date_released(&mut self, original_date_released: Timestamp) {
+        self.inner.set_year(original_date_released.to_string())
+    }
+    fn remove_original_date_released(&mut self) {
+        self.inner.remove_year()
+    }
+
+    fn date_recorded(&self) -> Option<Timestamp> {
+        if let Some(Ok(date)) = self.inner.year().map(Timestamp::from_str) {
+            Some(date)
+        } else {
+            None
+        }
+    }
+    fn set_date_recorded(&mut self, date_recorded: Timestamp) {
+        self.inner.set_year(date_recorded.to_string())
+    }
+    fn remove_date_recorded(&mut self) {
+        self.inner.remove_year()
     }
 
     fn year(&self) -> Option<i32> {

--- a/src/components/mp4_tag.rs
+++ b/src/components/mp4_tag.rs
@@ -11,7 +11,7 @@ impl<'a> From<&'a Mp4Tag> for AnyTag<'a> {
     fn from(inp: &'a Mp4Tag) -> Self {
         let title = inp.title();
         let artists = inp.artists().map(|i| i.into_iter().collect::<Vec<_>>());
-        let date = inp.date_recorded();
+        let date = inp.date();
         let year = inp.year();
         let duration = inp.duration();
         let album_title = inp.album_title();
@@ -141,45 +141,17 @@ impl AudioTagEdit for Mp4Tag {
         self.inner.add_artist(v);
     }
 
-    fn date_released(&self) -> Option<Timestamp> {
+    fn date(&self) -> Option<Timestamp> {
         if let Some(Ok(date)) = self.inner.year().map(Timestamp::from_str) {
             Some(date)
         } else {
             None
         }
     }
-    fn set_date_released(&mut self, date_released: Timestamp) {
-        self.inner.set_year(date_released.to_string())
+    fn set_date(&mut self, date: Timestamp) {
+        self.inner.set_year(date.to_string())
     }
-    fn remove_date_released(&mut self) {
-        self.inner.remove_year()
-    }
-
-    fn original_date_released(&self) -> Option<Timestamp> {
-        if let Some(Ok(date)) = self.inner.year().map(Timestamp::from_str) {
-            Some(date)
-        } else {
-            None
-        }
-    }
-    fn set_original_date_released(&mut self, original_date_released: Timestamp) {
-        self.inner.set_year(original_date_released.to_string())
-    }
-    fn remove_original_date_released(&mut self) {
-        self.inner.remove_year()
-    }
-
-    fn date_recorded(&self) -> Option<Timestamp> {
-        if let Some(Ok(date)) = self.inner.year().map(Timestamp::from_str) {
-            Some(date)
-        } else {
-            None
-        }
-    }
-    fn set_date_recorded(&mut self, date_recorded: Timestamp) {
-        self.inner.set_year(date_recorded.to_string())
-    }
-    fn remove_date_recorded(&mut self) {
+    fn remove_date(&mut self) {
         self.inner.remove_year()
     }
 

--- a/src/components/mp4_tag.rs
+++ b/src/components/mp4_tag.rs
@@ -11,9 +11,7 @@ impl<'a> From<&'a Mp4Tag> for AnyTag<'a> {
     fn from(inp: &'a Mp4Tag) -> Self {
         let title = inp.title();
         let artists = inp.artists().map(|i| i.into_iter().collect::<Vec<_>>());
-        let date_released = inp.date_released();
-        let original_date_released = inp.original_date_released();
-        let date_recorded = inp.date_recorded();
+        let date = inp.date_recorded();
         let year = inp.year();
         let duration = inp.duration();
         let album_title = inp.album_title();
@@ -34,9 +32,7 @@ impl<'a> From<&'a Mp4Tag> for AnyTag<'a> {
             config: inp.config,
             title,
             artists,
-            date_released,
-            original_date_released,
-            date_recorded,
+            date,
             year,
             duration,
             album_title,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -32,17 +32,9 @@ pub trait AudioTagEdit: AudioTagConfig {
         self.set_artist(artist);
     }
 
-    fn original_date_released(&self) -> Option<Timestamp>;
-    fn set_original_date_released(&mut self, date: Timestamp);
-    fn remove_original_date_released(&mut self);
-
-    fn date_released(&self) -> Option<Timestamp>;
-    fn set_date_released(&mut self, date: Timestamp);
-    fn remove_date_released(&mut self);
-
-    fn date_recorded(&self) -> Option<Timestamp>;
-    fn set_date_recorded(&mut self, date: Timestamp);
-    fn remove_date_recorded(&mut self);
+    fn date(&self) -> Option<Timestamp>;
+    fn set_date(&mut self, date: Timestamp);
+    fn remove_date(&mut self);
 
     fn year(&self) -> Option<i32>;
     fn set_year(&mut self, year: i32);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,5 @@
 use super::*;
+use id3::Timestamp;
 
 pub trait AudioTag: AudioTagEdit + AudioTagWrite + ToAnyTag {}
 
@@ -30,6 +31,18 @@ pub trait AudioTagEdit: AudioTagConfig {
     fn add_artist(&mut self, artist: &str) {
         self.set_artist(artist);
     }
+
+    fn original_date_released(&self) -> Option<Timestamp>;
+    fn set_original_date_released(&mut self, date: Timestamp);
+    fn remove_original_date_released(&mut self);
+
+    fn date_released(&self) -> Option<Timestamp>;
+    fn set_date_released(&mut self, date: Timestamp);
+    fn remove_date_released(&mut self);
+
+    fn date_recorded(&self) -> Option<Timestamp>;
+    fn set_date_recorded(&mut self, date: Timestamp);
+    fn remove_date_recorded(&mut self);
 
     fn year(&self) -> Option<i32>;
     fn set_year(&mut self, year: i32);

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -1,7 +1,9 @@
 use audiotags::{MimeType, Picture, Tag};
+use id3::Timestamp;
 use std::ffi::OsString;
 use std::fs;
 use std::path::Path;
+use std::str::FromStr;
 use tempfile::Builder;
 
 macro_rules! test_file {
@@ -27,6 +29,33 @@ macro_rules! test_file {
             tags.remove_artist();
             assert!(tags.artist().is_none());
             tags.remove_artist();
+
+            tags.set_date_released(Timestamp::from_str("2020-05-22").unwrap());
+            assert_eq!(
+                tags.date_released(),
+                Some(Timestamp::from_str("2020-05-22").unwrap())
+            );
+            tags.remove_date_released();
+            assert!(tags.date_released().is_none());
+            tags.remove_date_released();
+
+            tags.set_original_date_released(Timestamp::from_str("2020-05-22").unwrap());
+            assert_eq!(
+                tags.original_date_released(),
+                Some(Timestamp::from_str("2020-05-22").unwrap())
+            );
+            tags.remove_original_date_released();
+            assert!(tags.original_date_released().is_none());
+            tags.remove_original_date_released();
+
+            tags.set_date_recorded(Timestamp::from_str("2020-05-22").unwrap());
+            assert_eq!(
+                tags.date_recorded(),
+                Some(Timestamp::from_str("2020-05-22").unwrap())
+            );
+            tags.remove_date_recorded();
+            assert!(tags.date_recorded().is_none());
+            tags.remove_date_recorded();
 
             tags.set_year(2020);
             assert_eq!(tags.year(), Some(2020));

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -30,32 +30,14 @@ macro_rules! test_file {
             assert!(tags.artist().is_none());
             tags.remove_artist();
 
-            tags.set_date_released(Timestamp::from_str("2020-05-22").unwrap());
+            tags.set_date(Timestamp::from_str("2020-05-22").unwrap());
             assert_eq!(
-                tags.date_released(),
+                tags.date(),
                 Some(Timestamp::from_str("2020-05-22").unwrap())
             );
-            tags.remove_date_released();
-            assert!(tags.date_released().is_none());
-            tags.remove_date_released();
-
-            tags.set_original_date_released(Timestamp::from_str("2020-05-22").unwrap());
-            assert_eq!(
-                tags.original_date_released(),
-                Some(Timestamp::from_str("2020-05-22").unwrap())
-            );
-            tags.remove_original_date_released();
-            assert!(tags.original_date_released().is_none());
-            tags.remove_original_date_released();
-
-            tags.set_date_recorded(Timestamp::from_str("2020-05-22").unwrap());
-            assert_eq!(
-                tags.date_recorded(),
-                Some(Timestamp::from_str("2020-05-22").unwrap())
-            );
-            tags.remove_date_recorded();
-            assert!(tags.date_recorded().is_none());
-            tags.remove_date_recorded();
+            tags.remove_date();
+            assert!(tags.date().is_none());
+            tags.remove_date();
 
             tags.set_year(2020);
             assert_eq!(tags.year(), Some(2020));


### PR DESCRIPTION
Hi! Thank you for making this crate!

I noticed that there didn't seem to be a way to get the full date from a tag, only a year i32. The tags across flac/id3/mp4 all seem to support a full date in some sort of way, but it doesn't seem to be standard across them. The id3 library seems to be the most specific with how it handles the dates, so for this PR I initially went with specifying the dates with the most specificity across the formats, rather than attempting to keep it at the lowest common denominator (like it seems you might be trying to do). I also just reused the id3::Timestamp, which you might not find desirable, but I could change that to something more standard, if you have something in mind.

Also, forgive my ignorance on the audio specs. I'm not very familiar with them, so if this all seems like an anti-pattern, please let me know.

Thanks!