### PR TITLE
Add `Tag::date_raw` to get date string before `Timestamp` conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ readme-rustdocifier = "0.1.1"
 [features]
 default = ['from']
 from = []
+raw-date = []

--- a/src/components/flac_tag.rs
+++ b/src/components/flac_tag.rs
@@ -118,11 +118,7 @@ impl AudioTagEdit for FlacTag {
         }
     }
     fn date_raw(&self) -> Option<&str> {
-        if let Some(timestamp_raw) = self.get_first("DATE") {
-            Some(timestamp_raw)
-        } else {
-            None
-        }
+        self.get_first("DATE")
     }
     fn set_date(&mut self, date: Timestamp) {
         self.set_first("DATE", &date.to_string());

--- a/src/components/flac_tag.rs
+++ b/src/components/flac_tag.rs
@@ -117,6 +117,13 @@ impl AudioTagEdit for FlacTag {
             None
         }
     }
+    fn date_raw(&self) -> Option<&str> {
+        if let Some(timestamp_raw) = self.get_first("DATE") {
+            Some(timestamp_raw)
+        } else {
+            None
+        }
+    }
     fn set_date(&mut self, date: Timestamp) {
         self.set_first("DATE", &date.to_string());
     }

--- a/src/components/flac_tag.rs
+++ b/src/components/flac_tag.rs
@@ -17,7 +17,7 @@ impl<'a> From<AnyTag<'a>> for FlacTag {
             t.set_artist(&v)
         }
         if let Some(v) = inp.date {
-            t.set_date(v)
+            t.set_date(TimestampTag::Id3(v))
         }
         if let Some(v) = inp.year {
             t.set_year(v)
@@ -117,11 +117,17 @@ impl AudioTagEdit for FlacTag {
             None
         }
     }
-    fn date_raw(&self) -> Option<&str> {
+    #[cfg(feature = "raw-date")]
+    fn date_raw(&self) -> Option<TimestampTag> {
         self.get_first("DATE")
+            .map(|e| TimestampTag::Unknown(e.to_string()))
     }
-    fn set_date(&mut self, date: Timestamp) {
-        self.set_first("DATE", &date.to_string());
+    fn set_date(&mut self, date: TimestampTag) {
+        match date {
+            TimestampTag::Id3(date_fmt) => self.set_first("DATE", &date_fmt.to_string()),
+            #[cfg(feature = "raw-date")]
+            TimestampTag::Unknown(date_str) => self.set_first("DATE", &date_str.to_string()),
+        }
     }
     fn remove_date(&mut self) {
         self.remove("DATE");

--- a/src/components/id3_tag.rs
+++ b/src/components/id3_tag.rs
@@ -109,6 +109,11 @@ impl AudioTagEdit for Id3v2Tag {
     fn date(&self) -> Option<Timestamp> {
         self.inner.date_recorded()
     }
+    fn date_raw(&self) -> Option<&str> {
+        self.inner
+            .get("TDRC")
+            .and_then(|frame| frame.content().text())
+    }
     fn set_date(&mut self, timestamp: Timestamp) {
         self.inner.set_date_recorded(timestamp)
     }

--- a/src/components/mp4_tag.rs
+++ b/src/components/mp4_tag.rs
@@ -148,6 +148,9 @@ impl AudioTagEdit for Mp4Tag {
             None
         }
     }
+    fn date_raw(&self) -> Option<&str> {
+        self.inner.year()
+    }
     fn set_date(&mut self, date: Timestamp) {
         self.inner.set_year(date.to_string())
     }

--- a/src/components/mp4_tag.rs
+++ b/src/components/mp4_tag.rs
@@ -148,11 +148,18 @@ impl AudioTagEdit for Mp4Tag {
             None
         }
     }
-    fn date_raw(&self) -> Option<&str> {
-        self.inner.year()
+    #[cfg(feature = "raw-date")]
+    fn date_raw(&self) -> Option<TimestampTag> {
+        self.inner
+            .year()
+            .map(|e| TimestampTag::Unknown(e.to_string()))
     }
-    fn set_date(&mut self, date: Timestamp) {
-        self.inner.set_year(date.to_string())
+    fn set_date(&mut self, date: TimestampTag) {
+        match date {
+            TimestampTag::Id3(date_fmt) => self.inner.set_year(date_fmt.to_string()),
+            #[cfg(feature = "raw-date")]
+            TimestampTag::Unknown(date_str) => self.inner.set_year(date_str.to_string()),
+        }
     }
     fn remove_date(&mut self) {
         self.inner.remove_year()

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -33,6 +33,7 @@ pub trait AudioTagEdit: AudioTagConfig {
     }
 
     fn date(&self) -> Option<Timestamp>;
+    fn date_raw(&self) -> Option<&str>;
     fn set_date(&mut self, date: Timestamp);
     fn remove_date(&mut self);
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -33,8 +33,9 @@ pub trait AudioTagEdit: AudioTagConfig {
     }
 
     fn date(&self) -> Option<Timestamp>;
-    fn date_raw(&self) -> Option<&str>;
-    fn set_date(&mut self, date: Timestamp);
+    #[cfg(feature = "raw-date")]
+    fn date_raw(&self) -> Option<TimestampTag>;
+    fn set_date(&mut self, date: TimestampTag);
     fn remove_date(&mut self);
 
     fn year(&self) -> Option<i32>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,21 @@ pub enum MimeType {
     Gif,
 }
 
+/// The types of date for the timestamp.
+/// Most of the time you will want to use `TimestampTag::Id3` as it is using the
+/// standard specifications. However when you are working with audio with
+/// unknown date format or non-ISO then you can use `TimestampTag::Unknown` as
+/// an escape hatch to get the original text and parse to your own format
+/// if needed.
+///
+/// - To use TimestampTag you need to enable the `raw-date` feature
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TimestampTag {
+    Id3(id3::Timestamp),
+    #[cfg(feature = "raw-date")]
+    Unknown(String),
+}
+
 impl TryFrom<&str> for MimeType {
     type Error = crate::Error;
     fn try_from(inp: &str) -> crate::Result<Self> {

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -1,4 +1,4 @@
-use audiotags::{MimeType, Picture, Tag};
+use audiotags::{MimeType, Picture, Tag, TimestampTag};
 use id3::Timestamp;
 use std::ffi::OsString;
 use std::fs;
@@ -30,7 +30,7 @@ macro_rules! test_file {
             assert!(tags.artist().is_none());
             tags.remove_artist();
 
-            tags.set_date(Timestamp::from_str("2020-05-22").unwrap());
+            tags.set_date(TimestampTag::Id3(Timestamp::from_str("2020-05-22").unwrap()));
             assert_eq!(
                 tags.date(),
                 Some(Timestamp::from_str("2020-05-22").unwrap())


### PR DESCRIPTION
Right now `date()` will always attempt a conversion to `Timestamp`, and if the date format is not correct then not all fields will be returned. I think this can be a good escape hatch for getting the original date and parse to one's own format if needed.