### PR TITLE
Update convert macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,6 @@ impl TagType {
 #[macro_export]
 macro_rules! convert {
     ($inp:expr, $target_type:ty) => {
-        $target_type::from(inp.to_anytag())
+        <$target_type>::from($inp.to_anytag())
     };
 }


### PR DESCRIPTION
Fixes compiler error when using `convert!` with newer versions of rust