### PR TITLE
Use &Path instead of &str for path in write_to_path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
-name = "audiotags"
+name = "audiotags-qobuz"
 version = "0.5.0"
-authors = ["Tianyi <ShiTianyi2001@outlook.com>", "Pierre de la Martinière <pierre.de.la.martiniere@gmail.com>"]
+authors = ["Tianyi <ShiTianyi2001@outlook.com>", "Pierre de la Martinière <pierre.de.la.martiniere@gmail.com>", "Tarneo <tarneo@tarneo.fr>"]
 edition = "2021"
-description = "Unified IO for different types of audio metadata"
+description = "Unified IO for different types of audio metadata (qobuz fork)"
 license = "MIT"
-repository = "https://github.com/TianyiShi2001/audiotags"
-keywords = ["id3", "tag", "tags", "audio", "audiotags"]
+repository = "https://github.com/tarneaux/audiotags"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "audiotags-qobuz"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Tianyi <ShiTianyi2001@outlook.com>", "Pierre de la Martinière <pierre.de.la.martiniere@gmail.com>", "Tarneo <tarneo@tarneo.fr>"]
 edition = "2021"
 description = "Unified IO for different types of audio metadata (qobuz fork)"
 license = "MIT"
-repository = "https://github.com/tarneaux/audiotags"
+repository = "https://git.sr.ht/~tarneo/audiotags-qobuz"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/components/flac_tag.rs
+++ b/src/components/flac_tag.rs
@@ -287,7 +287,7 @@ impl AudioTagWrite for FlacTag {
         self.inner.write_to(file)?;
         Ok(())
     }
-    fn write_to_path(&mut self, path: &str) -> crate::Result<()> {
+    fn write_to_path(&mut self, path: &Path) -> crate::Result<()> {
         self.inner.write_to_path(path)?;
         Ok(())
     }

--- a/src/components/id3_tag.rs
+++ b/src/components/id3_tag.rs
@@ -264,7 +264,7 @@ impl AudioTagWrite for Id3v2Tag {
         self.inner.write_to(file, id3::Version::Id3v24)?;
         Ok(())
     }
-    fn write_to_path(&mut self, path: &str) -> crate::Result<()> {
+    fn write_to_path(&mut self, path: &Path) -> crate::Result<()> {
         self.inner.write_to_path(path, id3::Version::Id3v24)?;
         Ok(())
     }

--- a/src/components/mp4_tag.rs
+++ b/src/components/mp4_tag.rs
@@ -320,7 +320,7 @@ impl AudioTagWrite for Mp4Tag {
         self.inner.write_to(file)?;
         Ok(())
     }
-    fn write_to_path(&mut self, path: &str) -> crate::Result<()> {
+    fn write_to_path(&mut self, path: &Path) -> crate::Result<()> {
         self.inner.write_to_path(path)?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 //!
 //! ```rust,no_run
 //! use audiotags::{Tag, Picture, MimeType};
+//! use std::path::Path;
 //!
 //! // using `default()` or `new()` alone so that the metadata format is
 //! // guessed (from the file extension) (in this case, Id3v2 tag is read)
@@ -58,7 +59,7 @@
 //! assert!(tag.album_cover().is_none());
 //! tag.remove_album_cover();
 //!
-//! tag.write_to_path("test.mp3").expect("Fail to save");
+//! tag.write_to_path(Path::new("test.mp3")).expect("Fail to save");
 //! ```
 
 pub(crate) use audiotags_macro::*;
@@ -93,6 +94,7 @@ pub use std::convert::{TryFrom, TryInto};
 ///
 /// ```no_run
 /// use audiotags::{Tag, TagType};
+/// use std::path::Path;
 ///
 /// # fn main() -> audiotags::Result<()> {
 /// // Guess the format by default
@@ -100,7 +102,7 @@ pub use std::convert::{TryFrom, TryInto};
 /// tag.set_title("Foo");
 ///
 /// // you can convert the tag type and save the metadata to another file.
-/// tag.to_dyn_tag(TagType::Mp4).write_to_path("assets/a.m4a")?;
+/// tag.to_dyn_tag(TagType::Mp4).write_to_path(Path::new("assets/a.m4a"))?;
 ///
 /// // you can specify the tag type (but when you want to do this, also consider directly using the concrete type)
 /// let tag = Tag::new().with_tag_type(TagType::Mp4).read_from_path("assets/a.m4a").unwrap();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,6 @@
 use super::*;
 use id3::Timestamp;
+use std::path::Path;
 
 pub trait AudioTag: AudioTagEdit + AudioTagWrite + ToAnyTag {}
 
@@ -148,7 +149,7 @@ pub trait AudioTagEdit: AudioTagConfig {
 pub trait AudioTagWrite {
     fn write_to(&mut self, file: &mut File) -> crate::Result<()>;
     // cannot use impl AsRef<Path>
-    fn write_to_path(&mut self, path: &str) -> crate::Result<()>;
+    fn write_to_path(&mut self, path: &Path) -> crate::Result<()>;
 }
 
 pub trait AudioTagConfig {

--- a/tests/inner.rs
+++ b/tests/inner.rs
@@ -1,6 +1,7 @@
 use audiotags::*;
 use id3::TagLike;
 use std::fs;
+use std::path::Path;
 use tempfile::Builder;
 
 #[test]
@@ -24,7 +25,7 @@ fn test_inner() {
     let mut id3tag = tag.to_dyn_tag(TagType::Id3v2);
 
     id3tag
-        .write_to_path(tmp_path.to_str().unwrap())
+        .write_to_path(Path::new(tmp_path.to_str().unwrap()))
         .expect("Fail to write!");
 
     let id3tag_reload = Tag::default()


### PR DESCRIPTION
Since all underlying crates use a &Path as the type for writing, it makes much more sense to just use that as the type for `write_to_path`, especially since strs can be freely cast to Paths, but Paths can't be cast to strs all the time (since on some OSes, non-unicode characters are allowed in paths).