### PR TITLE
Add: compilation property

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["id3", "tag", "tags", "audio", "audiotags"]
 
 [dependencies]
 id3 = "1.10.0"
-mp4ameta = "0.11.0"
+mp4ameta = "0.13.0"
 metaflac = "0.2.5"
 thiserror = "1.0.50"
 audiotags-macro = { version = "0.2", path = "./audiotags-macro" }

--- a/src/anytag.rs
+++ b/src/anytag.rs
@@ -18,6 +18,7 @@ pub struct AnyTag<'a> {
     pub total_discs: Option<u16>,
     pub genre: Option<&'a str>,
     pub composer: Option<&'a str>,
+    pub compilation: bool,
     pub comment: Option<&'a str>,
 }
 
@@ -79,6 +80,12 @@ impl<'a> AnyTag<'a> {
     }
     pub fn composer(&self) -> Option<&str> {
         self.composer
+    }
+    pub fn compilation(&self) -> bool {
+        self.compilation
+    }
+    pub fn set_compilation(&mut self, compilation: bool) {
+        self.compilation = compilation;
     }
     pub fn comment(&self) -> Option<&str> {
         self.comment

--- a/src/components/flac_tag.rs
+++ b/src/components/flac_tag.rs
@@ -40,6 +40,9 @@ impl<'a> From<AnyTag<'a>> for FlacTag {
         if let Some(v) = inp.total_discs() {
             t.set_total_discs(v)
         }
+        if inp.compilation() {
+            t.set_compilation(true)
+        }
         t
     }
 }
@@ -61,6 +64,7 @@ impl<'a> From<&'a FlacTag> for AnyTag<'a> {
             total_discs: inp.total_discs(),
             genre: inp.genre(),
             composer: inp.composer(),
+            compilation: inp.compilation(),
             comment: inp.comment(),
             ..Self::default()
         };
@@ -269,6 +273,22 @@ impl AudioTagEdit for FlacTag {
     }
     fn remove_genre(&mut self) {
         self.remove("GENRE");
+    }
+
+    fn compilation(&self) -> bool {
+        self.get_first("COMPILATION")
+            .and_then(|v| v.parse::<u8>().ok())
+            .map_or(false, |n| n == 1)
+    }
+    fn set_compilation(&mut self, compilation: bool) {
+        if compilation {
+            self.set_first("COMPILATION", "1");
+        } else {
+            self.remove("COMPILATION");
+        }
+    }
+    fn remove_compilation(&mut self) {
+        self.remove("COMPILATION");
     }
 
     fn comment(&self) -> Option<&str> {

--- a/src/components/mp4_tag.rs
+++ b/src/components/mp4_tag.rs
@@ -167,7 +167,7 @@ impl AudioTagEdit for Mp4Tag {
 
     // Return Option with duration in second
     fn duration(&self) -> Option<f64> {
-        self.inner.duration().map(|d| d.as_secs_f64())
+        Some(self.inner.duration().as_secs_f64())
     }
 
     fn album_title(&self) -> Option<&str> {

--- a/src/components/mp4_tag.rs
+++ b/src/components/mp4_tag.rs
@@ -27,6 +27,7 @@ impl<'a> From<&'a Mp4Tag> for AnyTag<'a> {
         let total_discs = b;
         let genre = inp.genre();
         let composer = inp.composer();
+        let compilation = inp.compilation();
         let comment = inp.comment();
         Self {
             config: inp.config,
@@ -44,6 +45,7 @@ impl<'a> From<&'a Mp4Tag> for AnyTag<'a> {
             total_discs,
             genre,
             composer,
+            compilation,
             comment,
         }
     }
@@ -81,6 +83,9 @@ impl<'a> From<AnyTag<'a>> for Mp4Tag {
                 }
                 if let Some(v) = inp.total_discs() {
                     t.set_total_discs(v)
+                }
+                if inp.compilation() {
+                    t.set_compilation()
                 }
                 t
             },
@@ -302,6 +307,20 @@ impl AudioTagEdit for Mp4Tag {
     }
     fn remove_genre(&mut self) {
         self.inner.remove_genres();
+    }
+
+    fn compilation(&self) -> bool {
+        self.inner.compilation()
+    }
+    fn set_compilation(&mut self, compilation: bool) {
+        if compilation {
+            self.inner.set_compilation();
+        } else {
+            self.inner.remove_compilation();
+        }
+    }
+    fn remove_compilation(&mut self) {
+        self.inner.remove_compilation();
     }
 
     fn comment(&self) -> Option<&str> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -140,6 +140,10 @@ pub trait AudioTagEdit: AudioTagConfig {
     fn set_genre(&mut self, genre: &str);
     fn remove_genre(&mut self);
 
+    fn compilation(&self) -> bool;
+    fn set_compilation(&mut self, compilation: bool);
+    fn remove_compilation(&mut self);
+
     fn comment(&self) -> Option<&str>;
     fn set_comment(&mut self, genre: String);
     fn remove_comment(&mut self);

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -74,6 +74,11 @@ macro_rules! test_file {
             assert!(tags.genre().is_none());
             tags.remove_genre();
 
+            tags.set_compilation(true);
+            assert_eq!(tags.compilation(), true);
+            tags.remove_compilation();
+            assert!(!tags.compilation());
+
             tags.set_comment("foo song comment".to_string());
             assert_eq!(tags.comment(), Some("foo song comment"));
             tags.remove_comment();


### PR DESCRIPTION
Adds support for reading and writing compilation tags for all three formats.

```
ID3: TCMP
FLAC: COMPILATION
MPEG-4: cpil
```

I use it within my own project, so it seems to work.